### PR TITLE
sqllab: don't hold database deletion because of query reference (#1863)

### DIFF
--- a/superset/models.py
+++ b/superset/models.py
@@ -2591,7 +2591,10 @@ class Query(Model):
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=True)
 
     database = relationship(
-        'Database', foreign_keys=[database_id], backref='queries')
+        'Database',
+        foreign_keys=[database_id],
+        backref=backref('queries', cascade='all, delete-orphan')
+    )
     user = relationship(
         'User',
         backref=backref('queries', cascade='all, delete-orphan'),


### PR DESCRIPTION
Let people delete the database even if there are sqllab queries
on that database. Instead delete them too.

Fix #1848